### PR TITLE
support for Lagom 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ doing so can be challenging when running from SBT. These plugins take care of th
 Add the `sbt-kanela-runner` plugin to your `project/plugins.sbt` file using the code bellow:
 
 ```scala
-addSbtPlugin("io.kamon" % "sbt-kanela-runner" % "2.0.6")
+addSbtPlugin("io.kamon" % "sbt-kanela-runner" % "2.0.10")
 ```
 
 ### Important
@@ -50,13 +50,13 @@ For Play Framework 2.6 and 2.7 projects add the `sbt-kanela-runner-play-2.x` to 
 
 ```scala
 // For Play Framework 2.6
-addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.6" % "2.0.6")
+addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.6" % "2.0.10")
 
 // For Play Framework 2.7
-addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.7" % "2.0.6")
+addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.7" % "2.0.10")
 
 // For Play Framework 2.8
-addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.8" % "2.0.6")
+addSbtPlugin("io.kamon" % "sbt-kanela-runner-play-2.8" % "2.0.10")
 ```
 
 Then, you will need to enable the `JavaAgent` plugin on your Play project. Find your play project on your `build.sbt`
@@ -73,6 +73,25 @@ This plugin has been tested with **Play 2.8.0**, **Play 2.7.3** and **Play 2.6.2
 Just `run`, like you do all the time! A notice will be shown saying that you are running your application with Kanela.
 
 
+## Lagom Projects
+### Configuration
+
+For Lagom Framework 1.6 add the `sbt-kanela-runner-lagom-1.6` plugin to your `project/plugins.sbt` file:
+
+```scala
+addSbtPlugin("io.kamon" % "sbt-kanela-runner-lagom-1.6" % "2.0.10")
+```
+
+Then you will need to explicitly enable the `JavaAgent` and `SbtKanelaRunnerLagom` plugins in one (and only one) of your 
+Lagom implementation projects in the `build.sbt` file. Beware that Kanela can only instrument one service at a time:
+
+```scala
+lazy val `hello-impl` = (project in file("hello-impl"))
+  .enablePlugins(LagomScala, JavaAgent, SbtKanelaRunnerLagom)
+```
+
+### Running
+Execute `runAll` as you normally would.
 
 [sbt]: https://github.com/sbt/sbt
 [play]: https://www.playframework.com

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,12 @@ def crossSbtDependency(module: ModuleID, sbtVersion: String, scalaVersion: Strin
 val playSbtPluginFor26 = "com.typesafe.play" % "sbt-plugin" % "2.6.25"
 val playSbtPluginFor27 = "com.typesafe.play" % "sbt-plugin" % "2.7.9"
 val playSbtPluginFor28 = "com.typesafe.play" % "sbt-plugin" % "2.8.7"
+val lagomSbtPluginFor16 = "com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.4"
 
 
 lazy val sbtKanelaRunner = Project("sbt-kanela-runner", file("."))
   .settings(noPublishing: _*)
-  .aggregate(kanelaRunner, kanelaRunnerPlay26, kanelaRunnerPlay27, kanelaRunnerPlay28)
+  .aggregate(kanelaRunner, kanelaRunnerPlay26, kanelaRunnerPlay27, kanelaRunnerPlay28, kanelaRunnerLagom16)
 
 lazy val kanelaRunner = Project("kanela-runner", file("sbt-kanela-runner"))
   .settings(
@@ -71,6 +72,18 @@ lazy val kanelaRunnerPlay28 = Project("kanela-runner-play-28", file("sbt-kanela-
     bintrayPackage := "sbt-kanela-runner-play-2.8",
     libraryDependencies ++= Seq(
       crossSbtDependency(playSbtPluginFor28, (sbtBinaryVersion in pluginCrossBuild).value, scalaBinaryVersion.value)
+    )
+  )
+
+lazy val kanelaRunnerLagom16 = Project("kanela-runner-lagom-16", file("sbt-kanela-runner-lagom-1.6"))
+  .dependsOn(kanelaRunner)
+  .settings(
+    sbtPlugin := true,
+    name := "sbt-kanela-runner-lagom-1.6",
+    moduleName := "sbt-kanela-runner-lagom-1.6",
+    bintrayPackage := "sbt-kanela-runner-lagom-1.6",
+    libraryDependencies ++= Seq(
+      crossSbtDependency(lagomSbtPluginFor16, (sbtBinaryVersion in pluginCrossBuild).value, scalaBinaryVersion.value)
     )
   )
 

--- a/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/dev/KanelaReloader.scala
+++ b/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/dev/KanelaReloader.scala
@@ -1,0 +1,404 @@
+/*
+ * This file has been copied and modified from the official SBT Lagom Plugin
+ */
+
+package com.lightbend.lagom.dev
+
+import java.io.File
+import java.net.{URL, URLClassLoader}
+import java.security.AccessController
+import java.security.PrivilegedAction
+import java.time.Instant
+import java.util
+import java.util.Timer
+import java.util.TimerTask
+import java.util.concurrent.atomic.AtomicReference
+import play.core.Build
+import play.core.BuildLink
+import play.core.server.ReloadableServer
+import play.dev.filewatch.FileWatchService
+import play.dev.filewatch.SourceModificationWatch
+import play.dev.filewatch.WatchState
+
+import scala.collection.JavaConverters._
+import better.files.{File => _, _}
+import com.lightbend.lagom.dev.Reloader.{CompileResult, DevServer, DevServerBinding}
+import kamon.instrumentation.sbt.SbtKanelaRunner
+import org.slf4j.LoggerFactory
+
+object KanelaReloader {
+
+  case class Source(file: File, original: Option[File])
+
+  private val accessControlContext = AccessController.getContext
+
+  /**
+    * Execute f with context ClassLoader of Reloader
+    */
+  private def withReloaderContextClassLoader[T](f: => T): T = {
+    val thread    = Thread.currentThread
+    val oldLoader = thread.getContextClassLoader
+    // we use accessControlContext & AccessController to avoid a ClassLoader leak (ProtectionDomain class)
+    AccessController.doPrivileged(
+      new PrivilegedAction[T]() {
+        def run: T = {
+          try {
+            thread.setContextClassLoader(classOf[Reloader].getClassLoader)
+            f
+          } finally {
+            thread.setContextClassLoader(oldLoader)
+          }
+        }
+      },
+      accessControlContext
+    )
+  }
+
+  private def urls(cp: Seq[File]): Array[URL] = cp.map(_.toURI.toURL).toArray
+
+  /**
+    * Start the Lagom server in dev mode.
+    */
+  def startDevMode(
+                    parentClassLoader: ClassLoader,
+                    dependencyClasspath: Seq[File],
+                    reloadCompile: () => CompileResult,
+                    classLoaderDecorator: ClassLoader => ClassLoader,
+                    monitoredFiles: Seq[File],
+                    fileWatchService: FileWatchService,
+                    projectPath: File,
+                    devSettings: Seq[(String, String)],
+                    httpAddress: String,
+                    httpPort: Int,
+                    httpsPort: Int,
+                    reloadLock: AnyRef,
+                    kanelaAgentJar: File
+                  ): DevServer = {
+    /*
+     * We need to do a bit of classloader magic to run the Play application.
+     *
+     * There are six classloaders:
+     *
+     * 1. buildLoader, the classloader of the build tool plugin (sbt/maven lagom plugin).
+     * 2. parentClassLoader, a possibly shared classloader that may contain artifacts
+     *    that are known to not share state, eg Scala itself.
+     * 3. delegatingLoader, a special classloader that overrides class loading
+     *    to delegate shared classes for build link to the buildLoader, and accesses
+     *    the reloader.currentApplicationClassLoader for resource loading to
+     *    make user resources available to dependency classes.
+     * 4. applicationLoader, contains the application dependencies. Has the
+     *    delegatingLoader as its parent. Classes from the commonLoader and
+     *    the delegatingLoader are checked for loading first.
+     * 5. decoratedClassloader, allows the classloader to be decorated.
+     * 6. reloader.currentApplicationClassLoader, contains the user classes
+     *    and resources. Has applicationLoader as its parent, where the
+     *    application dependencies are found, and which will delegate through
+     *    to the buildLoader via the delegatingLoader for the shared link.
+     *    Resources are actually loaded by the delegatingLoader, where they
+     *    are available to both the reloader and the applicationLoader.
+     *    This classloader is recreated on reload. See PlayReloader.
+     *
+     * Someone working on this code in the future might want to tidy things up
+     * by splitting some of the custom logic out of the URLClassLoaders and into
+     * their own simpler ClassLoader implementations. The curious cycle between
+     * applicationLoader and reloader.currentApplicationClassLoader could also
+     * use some attention.
+     */
+
+
+    /**
+      * ClassLoader that delegates loading of shared build link classes to the
+      * buildLoader. Also accesses the reloader resources to make these available
+      * to the applicationLoader, creating a full circle for resource loading.
+      */
+
+    // Forces the Scala Library to be loaded from the dependency classpath by skipping
+    // the SBT ScalaInstance class loader. This will ensure that Kamon can apply Future-related
+    // instrumentation in development mode.
+    lazy val grandParentClassLoader = parentClassLoader
+      .getParent // Skips ScalaLoader
+      .getParent // Skips CachedClassLoader (also contains the Scala Library)
+
+    lazy val delegatingLoader: ClassLoader = buildDelegating(grandParentClassLoader, reloader.getClassLoader _)
+    lazy val applicationLoader = buildForApplication(dependencyClasspath, delegatingLoader)
+    lazy val decoratedLoader   = classLoaderDecorator(applicationLoader)
+
+    lazy val reloader = new KanelaReloader(
+      reloadCompile,
+      decoratedLoader,
+      projectPath,
+      devSettings,
+      monitoredFiles,
+      fileWatchService,
+      reloadLock,
+      kanelaAgentJar
+    )
+
+    SbtKanelaRunner.attachWithInstrumentationClassLoader(kanelaAgentJar, applicationLoader, clearRegistry = true)
+
+    val server: ReloadableServer = mainDev(applicationLoader, reloader, httpAddress, httpPort, httpsPort)
+    val _bindings = bindings(httpAddress, httpPort, httpsPort)
+
+    new DevServer {
+      val buildLink: BuildLink                   = reloader
+      def addChangeListener(f: () => Unit): Unit = reloader.addChangeListener(f)
+      def reload(): Unit                         = server.reload()
+      def close(): Unit = {
+        server.stop()
+        reloader.close()
+      }
+      def bindings(): Seq[DevServerBinding] = _bindings
+    }
+  }
+
+  /**
+    * Start the Lagom server without hot reloading
+    */
+  def startNoReload(
+                     parentClassLoader: ClassLoader,
+                     dependencyClasspath: Seq[File],
+                     buildProjectPath: File,
+                     devSettings: Seq[(String, String)],
+                     httpAddress: String,
+                     httpPort: Int,
+                     httpsPort: Int,
+                     kanelaAgentJar: File
+                   ): DevServer = {
+    lazy val delegatingLoader: ClassLoader = buildDelegating(parentClassLoader, () => Some(applicationLoader))
+    lazy val applicationLoader             = buildForApplication(dependencyClasspath, delegatingLoader)
+
+    val _buildLink = new BuildLink {
+      private val initialized = new java.util.concurrent.atomic.AtomicBoolean(false)
+      override def reload(): AnyRef = {
+        if (initialized.compareAndSet(false, true)) applicationLoader
+        else null // this means nothing to reload
+      }
+      override def projectPath(): File                                         = buildProjectPath
+      override def settings(): util.Map[String, String]                        = devSettings.toMap.asJava
+      override def forceReload(): Unit                                         = ()
+      override def findSource(className: String, line: Integer): Array[AnyRef] = null
+    }
+
+    SbtKanelaRunner.attachWithInstrumentationClassLoader(kanelaAgentJar, applicationLoader, clearRegistry = true)
+    val server: ReloadableServer = mainDev(applicationLoader, _buildLink, httpAddress, httpPort, httpsPort)
+
+    server.reload() // it's important to initialize the server
+
+    val _bindings = bindings(httpAddress, httpPort, httpsPort)
+
+    new DevServer {
+      val buildLink: BuildLink = _buildLink
+
+      /** Allows to register a listener that will be triggered a monitored file is changed. */
+      def addChangeListener(f: () => Unit): Unit = ()
+
+      /** Reloads the application.*/
+      def reload(): Unit = ()
+
+      /** List of bindings this server is exposing.*/
+      def bindings(): Seq[DevServerBinding] = _bindings
+
+      def close(): Unit = server.stop()
+    }
+  }
+
+  private def buildDelegating(
+                               parentClassLoader: ClassLoader,
+                               applicationClassLoader: () => Option[ClassLoader]
+                             ): ClassLoader = {
+    val buildLoader   = this.getClass.getClassLoader
+    val sharedClasses = Build.sharedClasses.asScala.toSet
+    new DelegatingClassLoader(parentClassLoader, sharedClasses, buildLoader, applicationClassLoader)
+  }
+
+  private def buildForApplication(dependencyClasspath: Seq[File], delegatingLoader: => ClassLoader): ClassLoader =
+    new NamedURLClassLoader("LagomDependencyClassLoader", urls(dependencyClasspath), delegatingLoader)
+
+  private def mainDev(
+                       applicationLoader: ClassLoader,
+                       buildLink: BuildLink,
+                       httpAddress: String,
+                       httpPort: Int,
+                       httpsPort: Int
+                     ): ReloadableServer = {
+    val mainClass = applicationLoader.loadClass("play.core.server.LagomReloadableDevServerStart")
+    val mainDev   = mainClass.getMethod("mainDev", classOf[BuildLink], classOf[String], classOf[Int], classOf[Int])
+    mainDev
+      .invoke(null, buildLink, httpAddress, httpPort: java.lang.Integer, httpsPort: java.lang.Integer)
+      .asInstanceOf[ReloadableServer]
+  }
+
+  private def bindings(httpAddress: String, httpPort: Int, httpsPort: Int): Seq[DevServerBinding] = {
+    val bindings = Seq.newBuilder[DevServerBinding]
+
+    bindings += DevServerBinding("HTTP", httpAddress, httpPort)
+
+    if (httpsPort > 0)
+      bindings += DevServerBinding("HTTPS", httpAddress, httpsPort)
+
+    bindings.result()
+  }
+
+  class NamedURLClassLoader(name: String, urls: Array[URL], parent: ClassLoader) extends URLClassLoader(urls, parent) {
+    override def toString: String = name + "{" + getURLs.map(_.toString).mkString(", ") + "}"
+  }
+}
+
+import Reloader._
+
+class KanelaReloader(
+                reloadCompile: () => CompileResult,
+                baseLoader: ClassLoader,
+                val projectPath: File,
+                devSettings: Seq[(String, String)],
+                monitoredFiles: Seq[File],
+                fileWatchService: FileWatchService,
+                reloadLock: AnyRef,
+                kanelaAgentJar: File
+              ) extends BuildLink {
+  // The current classloader for the application
+  @volatile private var currentApplicationClassLoader: Option[ClassLoader] = None
+  // Flag to force a reload on the next request.
+  // This is set if a compile error occurs, and also by the forceReload method on BuildLink, which is called for
+  // example when evolutions have been applied.
+  @volatile private var forceReloadNextTime = false
+  // Whether any source files have changed since the last request.
+  @volatile private var changed = false
+  // The last successful compile results. Used for rendering nice errors.
+  @volatile private var currentSourceMap = Option.empty[Map[String, Source]]
+  // A watch state for the classpath. Used to determine whether anything on the classpath has changed as a result
+  // of compilation, and therefore a new classloader is needed and the app needs to be reloaded.
+  @volatile private var watchState: WatchState = WatchState.empty
+
+  // Stores the most recent time that a file was changed
+  private val fileLastChanged = new AtomicReference[Instant]()
+
+  // Create the watcher, updates the changed boolean when a file has changed.
+  private val watcher = fileWatchService.watch(monitoredFiles, () => {
+    changed = true
+    onChange()
+  })
+  private val classLoaderVersion = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  private val quietTimeTimer = new Timer("reloader-timer", true)
+
+  private val listeners = new java.util.concurrent.CopyOnWriteArrayList[() => Unit]()
+
+  private val quietPeriodMs = 200L
+  private def onChange(): Unit = {
+    val now = Instant.now()
+    fileLastChanged.set(now)
+    // set timer task
+    quietTimeTimer.schedule(new TimerTask {
+      override def run(): Unit = quietPeriodFinished(now)
+    }, quietPeriodMs)
+  }
+
+  private def quietPeriodFinished(start: Instant): Unit = {
+    // If our start time is equal to the most recent start time stored, then execute the handlers and set the most
+    // recent time to null, otherwise don't do anything.
+    if (fileLastChanged.compareAndSet(start, null)) {
+      import scala.collection.JavaConverters._
+      listeners.iterator().asScala.foreach(listener => listener())
+    }
+  }
+
+  def addChangeListener(f: () => Unit): Unit = listeners.add(f)
+
+  /**
+    * Contrary to its name, this doesn't necessarily reload the app.  It is invoked on every request, and will only
+    * trigger a reload of the app if something has changed.
+    *
+    * Since this communicates across classloaders, it must return only simple objects.
+    *
+    *
+    * @return Either
+    * - Throwable - If something went wrong (eg, a compile error).
+    * - ClassLoader - If the classloader has changed, and the application should be reloaded.
+    * - null - If nothing changed.
+    */
+  def reload: AnyRef = {
+    reloadLock.synchronized {
+      if (changed || forceReloadNextTime || currentSourceMap.isEmpty || currentApplicationClassLoader.isEmpty) {
+        val shouldReload = forceReloadNextTime
+
+        changed = false
+        forceReloadNextTime = false
+
+        // use Reloader context ClassLoader to avoid ClassLoader leaks in sbt/scala-compiler threads
+        KanelaReloader.withReloaderContextClassLoader {
+          // Run the reload task, which will trigger everything to compile
+          reloadCompile() match {
+            case CompileFailure(exception) =>
+              // We force reload next time because compilation failed this time
+              forceReloadNextTime = true
+              exception
+
+            case CompileSuccess(sourceMap, classpath) =>
+              currentSourceMap = Some(sourceMap)
+
+              // We only want to reload if the classpath has changed.  Assets don't live on the classpath, so
+              // they won't trigger a reload.
+              // Use the SBT watch service, passing true as the termination to force it to break after one check
+              val (_, newState) = SourceModificationWatch.watch(
+                () =>
+                  classpath.iterator
+                    .filter(_.exists())
+                    .flatMap(_.toScala.listRecursively),
+                0,
+                watchState
+              )(true)
+              // SBT has a quiet wait period, if that's set to true, sources were modified
+              val triggered = newState.awaitingQuietPeriod
+              watchState = newState
+
+              if (triggered || shouldReload || currentApplicationClassLoader.isEmpty) {
+                // Create a new classloader
+                val version = classLoaderVersion.incrementAndGet
+                val name    = "ReloadableClassLoader(v" + version + ")"
+                val urls    = KanelaReloader.urls(classpath)
+                SbtKanelaRunner.attachWithInstrumentationClassLoader(kanelaAgentJar, baseLoader, clearRegistry = false)
+                val loader  = new DelegatedResourcesClassLoader(name, urls, baseLoader)
+                currentApplicationClassLoader = Some(loader)
+                loader
+              } else {
+                null // null means nothing changed
+              }
+          }
+        }
+      } else {
+        null // null means nothing changed
+      }
+    }
+  }
+
+  lazy val settings: util.Map[String, String] = {
+    import scala.collection.JavaConverters._
+    devSettings.toMap.asJava
+  }
+
+  def forceReload() {
+    forceReloadNextTime = true
+  }
+
+  def findSource(className: String, line: java.lang.Integer): Array[java.lang.Object] = {
+    val topType = className.split('$').head
+    currentSourceMap.flatMap { sources =>
+      sources.get(topType).map { source =>
+        Array[java.lang.Object](source.original.getOrElse(source.file), line)
+      }
+    }.orNull
+  }
+
+  def runTask(task: String): AnyRef =
+    throw new UnsupportedOperationException("This BuildLink does not support running arbitrary tasks")
+
+  def close(): Unit = {
+    currentApplicationClassLoader = None
+    currentSourceMap = None
+    watcher.stop()
+    quietTimeTimer.cancel()
+  }
+
+  def getClassLoader: Option[ClassLoader] = currentApplicationClassLoader
+}

--- a/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/sbt/SbtKanelaRunnerLagom.scala
+++ b/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/sbt/SbtKanelaRunnerLagom.scala
@@ -1,0 +1,159 @@
+package com.lightbend.lagom.sbt
+
+import com.lightbend.lagom.dev.{MiniLogger, StaticServiceLocations}
+import com.lightbend.lagom.dev.Reloader.DevServer
+import com.lightbend.lagom.dev.Servers.ServerContainer
+import com.lightbend.lagom.sbt.LagomPlugin.autoImport.{lagomCassandraPort, lagomKafkaAddress, lagomRun, lagomServiceGatewayAddress, lagomServiceGatewayImpl, lagomServiceGatewayPort, lagomServiceLocatorAddress, lagomServiceLocatorPort, lagomServiceLocatorStart, lagomServiceLocatorStop, lagomUnmanagedServices}
+import com.lightbend.lagom.sbt.run.KanelaRunSupport
+import com.lightbend.sbt.javaagent.JavaAgent
+import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.javaAgents
+import kamon.instrumentation.sbt.{KanelaOnSystemClassLoader, SbtKanelaRunner}
+import kamon.instrumentation.sbt.SbtKanelaRunner.Keys.kanelaVersion
+import sbt.Def.Initialize
+import sbt.Keys.{managedClasspath, name, state}
+import sbt.{Def, inScope, _}
+
+import java.io.Closeable
+import java.net.{URI, URL, URLClassLoader}
+import java.util.{Map => JMap}
+import scala.collection.JavaConverters._
+
+object SbtKanelaRunnerLagom extends AutoPlugin {
+
+  //  override def trigger = AllRequirements
+  override def requires = Lagom && SbtKanelaRunner && JavaAgent
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    javaAgents += "io.kamon" % "kanela-agent" % kanelaVersion.value,
+    lagomRun := {
+      val service = runLagomTask.value
+      // eagerly loads the service
+      service.reload()
+      // install a listener that will take care of reloading on classpath's changes
+      service.addChangeListener(() => service.reload())
+      (name.value, service)
+    },
+  )
+
+  override def buildSettings: Seq[Def.Setting[_]] = inScope(ThisScope in LagomPlugin.extraProjects.head)(Seq(
+    lagomServiceLocatorStart in ThisBuild := startServiceLocatorTask.value,
+    lagomServiceLocatorStop in ThisBuild := ServiceLocator.tryStop(new SbtLoggerProxy(state.value.log))
+  ))
+
+  private lazy val runLagomTask: Initialize[Task[DevServer]] = Def.taskDyn {
+    KanelaRunSupport.reloadRunTask(LagomPlugin.managedSettings.value)
+  }
+
+  private lazy val startServiceLocatorTask = Def.task {
+    val unmanagedServices: Map[String, String] =
+      StaticServiceLocations.staticServiceLocations(lagomCassandraPort.value, lagomKafkaAddress.value) ++ lagomUnmanagedServices.value
+
+    val serviceLocatorAddress  = lagomServiceLocatorAddress.value
+    val serviceLocatorPort     = lagomServiceLocatorPort.value
+    val serviceGatewayAddress  = lagomServiceGatewayAddress.value
+    val serviceGatewayHttpPort = lagomServiceGatewayPort.value
+    val serviceGatewayImpl     = lagomServiceGatewayImpl.value
+    val classpathUrls          = (managedClasspath in Compile).value.files.map(_.toURI.toURL).toArray
+    val scalaInstance          = Keys.scalaInstance.value
+    val log                    = new SbtLoggerProxy(state.value.log)
+
+    ServiceLocator.start(
+      log,
+      scalaInstance.loader,
+      classpathUrls,
+      serviceLocatorAddress,
+      serviceLocatorPort,
+      serviceGatewayAddress,
+      serviceGatewayHttpPort,
+      unmanagedServices,
+      serviceGatewayImpl
+    )
+  }
+
+  class LagomServiceLocatorClassLoader(urls: Array[URL], parent: ClassLoader) extends URLClassLoader(urls, parent)
+
+  object ServiceLocator extends ServerContainer {
+    protected type Server = Closeable {
+      def start(
+          serviceLocatorAddress: String,
+          serviceLocatorPort: Int,
+          serviceGatewayAddress: String,
+          serviceGatewayHttpPort: Int,
+          unmanagedServices: JMap[String, String],
+          gatewayImpl: String
+      ): Unit
+      def serviceLocatorAddress: URI
+      def serviceGatewayAddress: URI
+    }
+
+    def start(
+               log: MiniLogger,
+               parentClassLoader: ClassLoader,
+               classpath: Array[URL],
+               serviceLocatorAddress: String,
+               serviceLocatorPort: Int,
+               serviceGatewayAddress: String,
+               serviceGatewayHttpPort: Int,
+               unmanagedServices: Map[String, String],
+               gatewayImpl: String
+             ): Closeable =
+      synchronized {
+        if (server == null) {
+          withContextClassloader(new LagomServiceLocatorClassLoader(classpath, parentClassLoader)) { loader =>
+            val serverClass = loader.loadClass("com.lightbend.lagom.registry.impl.ServiceLocatorServer")
+            server = serverClass.getDeclaredConstructor().newInstance().asInstanceOf[Server]
+            try {
+              server.start(
+                serviceLocatorAddress,
+                serviceLocatorPort,
+                serviceGatewayAddress,
+                serviceGatewayHttpPort,
+                unmanagedServices.asJava,
+                gatewayImpl
+              )
+            } catch {
+              case e: Exception =>
+                val msg = "Failed to start embedded Service Locator or Service Gateway. " +
+                  s"Hint: Are ports $serviceLocatorPort or $serviceGatewayHttpPort already in use?"
+                stop()
+                throw new RuntimeException(msg, e)
+            }
+          }
+        }
+        if (server != null) {
+          log.info("Service locator is running at " + server.serviceLocatorAddress)
+          // TODO: trace all valid locations for the service gateway.
+          log.info("Service gateway is running at " + server.serviceGatewayAddress)
+        }
+
+        new Closeable {
+          override def close(): Unit = stop(log)
+        }
+      }
+
+    private def withContextClassloader[T](loader: ClassLoader)(body: ClassLoader => T): T = {
+      val current = Thread.currentThread().getContextClassLoader
+      try {
+        Thread.currentThread().setContextClassLoader(loader)
+        body(loader)
+      } finally Thread.currentThread().setContextClassLoader(current)
+    }
+
+    protected def stop(log: MiniLogger): Unit =
+      synchronized {
+        if (server == null) {
+          log.info("Service locator was already stopped")
+        } else {
+          log.info("Stopping service locator")
+          stop()
+        }
+      }
+
+    private def stop(): Unit =
+      synchronized {
+        try server.close()
+        catch { case _: Exception => () }
+        finally server = null
+      }
+  }
+}

--- a/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/sbt/run/KanelaRunSupport.scala
+++ b/sbt-kanela-runner-lagom-1.6/src/main/scala/com/lightbend/lagom/sbt/run/KanelaRunSupport.scala
@@ -1,0 +1,94 @@
+/*
+ * This file has been copied and modified from the official SBT Lagom Plugin
+ */
+
+package com.lightbend.lagom.sbt.run
+
+import com.lightbend.lagom.dev.{KanelaReloader, Reloader}
+import com.lightbend.lagom.sbt.Internal
+import com.lightbend.lagom.sbt.LagomPlugin.autoImport._
+import com.lightbend.lagom.sbt.LagomReloadableService.autoImport._
+import kamon.instrumentation.sbt.SbtKanelaRunner
+import sbt._
+import sbt.Keys._
+
+private[sbt] object KanelaRunSupport extends RunSupportCompat {
+  def reloadRunTask(
+      extraConfigs: Map[String, String]
+    ): Def.Initialize[Task[Reloader.DevServer]] = Def.task {
+    val state = Keys.state.value
+    val scope = resolvedScoped.value.scope
+
+    val reloadCompile = () =>
+      KanelaRunSupport.compile(
+        () => Project.runTask(lagomReload in scope, state).map(_._2).get,
+        () => Project.runTask(lagomReloaderClasspath in scope, state).map(_._2).get,
+        () => Project.runTask(streamsManager in scope, state).map(_._2).get.toEither.right.toOption
+      )
+
+    val classpath = (devModeDependencies.value ++ (externalDependencyClasspath in Runtime).value).distinct.files
+
+    KanelaReloader.startDevMode(
+      scalaInstance.value.loader,
+      classpath,
+      reloadCompile,
+      lagomClassLoaderDecorator.value,
+      lagomWatchDirectories.value,
+      lagomFileWatchService.value,
+      baseDirectory.value,
+      extraConfigs.toSeq ++ lagomDevSettings.value,
+      lagomServiceAddress.value,
+      selectHttpPortToUse.value,
+      lagomServiceHttpsPort.value,
+      KanelaRunSupport,
+      SbtKanelaRunner.Keys.kanelaAgentJar.value
+    )
+  }
+
+  def nonReloadRunTask(
+      extraConfigs: Map[String, String]
+    ): Def.Initialize[Task[Reloader.DevServer]] = Def.task {
+    val classpath = (devModeDependencies.value ++ (fullClasspath in Runtime).value).distinct
+
+    val buildLinkSettings = extraConfigs.toSeq ++ lagomDevSettings.value
+    KanelaReloader.startNoReload(
+      scalaInstance.value.loader,
+      classpath.map(_.data),
+      baseDirectory.value,
+      buildLinkSettings,
+      lagomServiceAddress.value,
+      selectHttpPortToUse.value,
+      lagomServiceHttpsPort.value,
+      SbtKanelaRunner.Keys.kanelaAgentJar.value
+    )
+  }
+
+  /**
+    * This task will calculate which port should be used for http.
+    * To keep backward compatibility, we detect if the user have manually configured lagomServicePort in which
+    * case we read the value set by the user and we don't use generated port.
+    *
+    * This task must be removed together with the deprecated lagomServicePort.
+    */
+  private def selectHttpPortToUse = Def.task {
+    val logger                = Keys.sLog.value
+    val deprecatedServicePort = lagomServicePort.value
+    val serviceHttpPort       = lagomServiceHttpPort.value
+    val generatedHttpPort     = lagomGeneratedServiceHttpPortCache.value
+    val isUsingGeneratedPort  = serviceHttpPort == generatedHttpPort
+
+    // deprecated setting was modified by user.
+    if (deprecatedServicePort != -1 && isUsingGeneratedPort) {
+      deprecatedServicePort
+    } else if (deprecatedServicePort != -1 && !isUsingGeneratedPort) {
+      logger.warn(
+        s"Both 'lagomServiceHttpPort' ($serviceHttpPort) and 'lagomServicePort' ($deprecatedServicePort) are configured, 'lagomServicePort' will be ignored"
+      )
+      serviceHttpPort
+    } else serviceHttpPort
+  }
+
+  private def devModeDependencies = Def.task {
+    (managedClasspath in Internal.Configs.DevRuntime).value
+  }
+}

--- a/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
+++ b/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
@@ -25,7 +25,7 @@ import net.bytebuddy.agent.ByteBuddyAgent
 object SbtKanelaRunner extends AutoPlugin {
 
   val KanelaRunner = config("kanela-runner")
-  val DefaultKanelaVersion = "1.0.7"
+  val DefaultKanelaVersion = "1.0.8"
   val InstrumentationClassLoaderProp = "kanela.instrumentation.classLoader"
 
   object Keys {
@@ -45,7 +45,8 @@ object SbtKanelaRunner extends AutoPlugin {
     kanelaAgentJar := findKanelaAgentJar.value,
     kanelaRunnerJvmForkOptions := jvmForkOptions.value,
     libraryDependencies += kanelaAgentDependency.value,
-    runner in run in Compile := kanelaRunnerTask.value
+    runner in run in Compile := kanelaRunnerTask.value,
+    resolvers += Resolver.mavenLocal
   )
 
   def kanelaAgentDependency = Def.setting {


### PR DESCRIPTION
Allows to instrument one (and only one) Lagom microservice when running on development mode. The approach is very similar to what we did with Play: we change the Reloader implementation for ours and change a few class loaders to ensure that Kanela will pick the right classes from the right places.

There is a lot of hackery going on, but so far I couldn't find any better way. Also, this not production code so I'm not super concerned about it.