### PR TITLE
Deduplicates java options used by both user and sbt-kanela-runner

### DIFF
--- a/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
+++ b/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
@@ -67,9 +67,9 @@ object SbtKanelaRunner extends AutoPlugin {
     if ((run / fork).value) {
       Def.task {
         val currentForkOptions = forkOptions.value
-        val runForkOptions = currentForkOptions.withRunJVMOptions {
-          ((run / javaOptions).value ++ currentForkOptions.runJVMOptions).toVector
-        }
+        val userJavaOptions = (run / javaOptions).value
+        val mergedOptions = (userJavaOptions ++ currentForkOptions.runJVMOptions).distinct
+        val runForkOptions = currentForkOptions.withRunJVMOptions(mergedOptions.toVector)
 
         new ForkRun(runForkOptions)
       }

--- a/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
+++ b/sbt-kanela-runner/src/main/scala/kamon/instrumentation/sbt/SbtKanelaRunner.scala
@@ -68,7 +68,7 @@ object SbtKanelaRunner extends AutoPlugin {
       Def.task {
         val currentForkOptions = forkOptions.value
         val userJavaOptions = (run / javaOptions).value
-        val mergedOptions = (userJavaOptions ++ currentForkOptions.runJVMOptions).distinct
+        val mergedOptions = mergeJvmOptions(currentForkOptions.runJVMOptions, userJavaOptions)
         val runForkOptions = currentForkOptions.withRunJVMOptions(mergedOptions.toVector)
 
         new ForkRun(runForkOptions)
@@ -97,6 +97,20 @@ object SbtKanelaRunner extends AutoPlugin {
           }
         }
     }
+  }
+
+  private def mergeJvmOptions(currentForkOptions: Seq[String], userJavaOptions: Seq[String]): Seq[String] = {
+    def agentLibName(opt: String): Option[String] =
+      if (opt.startsWith("-agentlib:")) Some(opt.stripPrefix("-agentlib:").split("=")(0))
+      else None
+
+    val overrideAgents: Map[String, String] =
+      userJavaOptions.foldLeft(Map.empty[String, String]) { (acc, opt) =>
+        agentLibName(opt).fold(acc)(name => acc + (name -> opt))
+      }
+
+    val deduplicatedBase = currentForkOptions.filterNot(opt => agentLibName(opt).exists(overrideAgents.contains))
+    deduplicatedBase ++ userJavaOptions
   }
 
   @volatile private var hasBeenAttached = false


### PR DESCRIPTION
Fixes bug that allows user and sbt-kanela-runner java options to conflict if used in both places.