### PR TITLE
Specifiying sonatype credential host, as required by com.github.sbt 11.1.2 plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@
 
 import sbt.Keys._
 import sbt._
+import xerial.sbt.Sonatype.autoImport.*
 
 import java.net.URL
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ inThisBuild(List(
   scmInfo := Some(ScmInfo(
     new URL("https://github.com/kamon-io/sbt-kanela-runner"),
     "scm:git:https://github.com/kamon-io/sbt-kanela-runner.git"
-  ))
+  )),
+  sonatypeCredentialHost := "oss.sonatype.org"
 ))
 
 def crossSbtDependency(module: ModuleID, sbtVersion: String, scalaVersion: String): ModuleID = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")


### PR DESCRIPTION
The new version of sbt-ci-release (1.11.2) doesn't know which Sonatype repository to use by default. Version 1.5.7 had Sonatype OSS baked in.  This specifies to use Sonatype OSS over Sonatype Central, which is the new default